### PR TITLE
修正正则表达式规则错误

### DIFF
--- a/task/utils/extract_info.py
+++ b/task/utils/extract_info.py
@@ -12,7 +12,9 @@ def extract_by_re(conetnt, regular_expression):
     m = re.search(regular_expression, conetnt)
 
     if m:
-        return m.groups()[0]
+        return m.group()
+    elif m == None:
+        return "未检测到相关内容"
     else:
         logger.error('{} 无法使用正则提取'.format(regular_expression))
         raise Exception('无法使用正则提取')


### PR DESCRIPTION
1. 直接返回所有正则表达式提取的内容
2. 正则表达式未匹配时返回友好提示

close #32 