### PR TITLE
修改正则表达式输出为分组1

### DIFF
--- a/task/utils/extract_info.py
+++ b/task/utils/extract_info.py
@@ -13,7 +13,7 @@ def extract_by_re(conetnt, regular_expression):
     m = re.search(regular_expression, conetnt)
 
     if m:
-        return m.group()
+        return m.group(1)
     elif not m:
         return "未检测到相关内容"
     else:


### PR DESCRIPTION
原为输入所有正则表达式捕获对象，实际使用中可能只关心“以AAAAAA开头后的BBBBBB”内容变化，故可以用括号将BBBBB设置为分组1后输出。