### PR TITLE
修改Server酱API至新版

### DIFF
--- a/task/utils/notification/wechat_notification.py
+++ b/task/utils/notification/wechat_notification.py
@@ -15,9 +15,9 @@ class WechatNotification(Notification):
             logger.error('没有设置Server酱 SCKEY，无法发送微信通知')
             raise Exception('没有设置Server酱 SCKEY，无法发送微信通知')
         data = {'text': header, 'desp': content}
-        url = 'https://sc.ftqq.com/{}.send'.format(to)
+        url = 'https://sctapi.ftqq.com/{}.send'.format(to)
         r = requests.post(url, data=data)
 
         res = json.loads(r.text)
-        if res['errno'] != 0:
-            raise Exception(res['errmsg'])
+        if res['data']['errno'] != 0:
+            raise Exception(res['data']['errmsg'])


### PR DESCRIPTION
微信推送-Server酱的API发生变化。修改了代码中的请求URL与返回值的判断逻辑。新版API说明文档：https://sct.ftqq.com/sendkey

### bug现象
可以成功发送信息至微信，但是程序后台会显示发送失败，并一直重复发送信息

### bug原因
如果请求Server酱的旧版API，将会被强制跳转至新API，所以信息可以成功发送。但新版API的返回值与旧版不同，因此程序会认为信息发送失败，因而每次重新获取网页变化时，都会重新发送一次信息